### PR TITLE
Use js variable to set daysInYear for html elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,18 +45,18 @@ body {
     <div id="sliders">
         <div class="wrap">
             <label for="DurationSlider">Duration (Days)</label>
-            <input type="range" id="DurationSlider" class="slider-wide" orient="vertical" min="1" max="365" value="365" name="duration" oninput="updateDuration(this.value)" onchange="updateDuration(this.value)">
-            <label id=DurationValueLabel for="DurationSlider">365</label>
+            <input type="range" id="DurationSlider" class="slider-wide" orient="horizontal" min="1" max="0" value="0" name="duration" oninput="updateDuration(this.value)" onchange="updateDuration(this.value)">
+            <label id="DurationValueLabel" for="DurationSlider">0</label>
         </div>
         <div class="wrap">
             <label for="GasSlider">Annual Gas Usage Estimate (kWH)</label>
-            <input type="range" id="GasSlider" class="slider-wide" orient="vertical" min="0" max="20000" value="5251" name="gas" oninput="updateGas(this.value)" onchange="updateGas(this.value)">
-            <label id=GasValueLabel for="GasSlider">5251</label>
+            <input type="range" id="GasSlider" class="slider-wide" orient="horizontal" min="0" max="20000" value="5251" name="gas" oninput="updateGas(this.value)" onchange="updateGas(this.value)">
+            <label id="GasValueLabel" for="GasSlider">5251</label>
         </div>
         <div class="wrap">
             <label for="ElectricitySlider">Annual Electricity Usage Estimate (kWH)</label>
-            <input type="range" id="ElectricitySlider" class="slider-wide" orient="vertical" min="0" max="20000" value="1748" name="electricity" oninput="updateElectricity(this.value)" onchange="updateElectricity(this.value)">
-            <label id=ElectricityValueLabel for="ElectricitySlider">1748</label>
+            <input type="range" id="ElectricitySlider" class="slider-wide" orient="horizontal" min="0" max="20000" value="1748" name="electricity" oninput="updateElectricity(this.value)" onchange="updateElectricity(this.value)">
+            <label id="ElectricityValueLabel" for="ElectricitySlider">1748</label>
         </div>
 
     </div>
@@ -92,6 +92,14 @@ var svg = d3.select("body").append("svg")
     .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
 var daysInYear = 365;
+
+var yearsSlider = document.getElementById("DurationSlider");
+yearsSlider.setAttribute("max", daysInYear);
+yearsSlider.setAttribute("value", daysInYear);
+
+var yearsLabel = document.getElementById("DurationValueLabel");
+yearsLabel.innerHTML = daysInYear;
+
 var settings = [daysInYear, daysInYear, 1748, 5251, 1];
 function updateDuration(newValue) {
     document.querySelector('#DurationValueLabel').innerHTML = newValue


### PR DESCRIPTION
- Updated js script to use daysInYear variable for updating the max and value of yearsSlider and the label text
- Changed orientation to horizontal instead of vertical to be consistent across different browsers
